### PR TITLE
Downgrade playground image to ubuntu:22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ the image.
 |**Name**        |**Version**|**Path**                                      |**Dockerhub**                                                                               |
 |----------------|:---------:|----------------------------------------------|--------------------------------------------------------------------------------------------|
 |*mdbook*        |`0.1.0`    |[./mdbook](./mdbook/README.md)                |[mdbook](https://hub.docker.com/repository/docker/thenerdlygentleman/mdbook)                |
-|*playground*    |`0.1.0`    |[./playground](./playground/README.md)        |[playground](https://hub.docker.com/repository/docker/thenerdlygentleman/playground)        |
+|*playground*    |`0.1.1`    |[./playground](./playground/README.md)        |[playground](https://hub.docker.com/repository/docker/thenerdlygentleman/playground)        |
 |*robotframework*|`0.1.0`    |[./robotframework](./robotframework/README.md)|[robotframework](https://hub.docker.com/repository/docker/thenerdlygentleman/robotframework)|

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     image: mdbook:0.1.0
   playground:
     build: playground
-    image: playground:0.1.0
+    image: playground:0.1.1
   robotframework:
     build: robotframework
     image: robotframework:0.1.0

--- a/playground/Dockerfile
+++ b/playground/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:22.04
 
 
 # USER HOME


### PR DESCRIPTION
24.04 contains the ubuntu user, which leads to workspace permission issues in dev containers.